### PR TITLE
Fix comments appearing multiple times.

### DIFF
--- a/src/lib/model/app/app.ts
+++ b/src/lib/model/app/app.ts
@@ -97,7 +97,7 @@ export class App {
 	serialize() {
 		return attemptAsync<MatchSchemaType>(async () => {
 			const trace = this.state.serialize();
-			const { checks, sliders, } = this.checks.serialize();
+			const { checks, sliders } = this.checks.serialize();
 			const comments = this.comments.serialize();
 			const { eventKey, compLevel, match, team } = this.matchData.data;
 			const { scout, prescouting, practice, flipX, flipY } = globalData;
@@ -121,7 +121,7 @@ export class App {
 				practice,
 				alliance,
 				group,
-				sliders,
+				sliders
 			};
 		});
 	}
@@ -138,17 +138,19 @@ export class App {
 	init(target: HTMLElement) {
 		this._target = target;
 		this._offState = this.state.init();
+		this._offComments = this.comments.init();
 		this._offView = this.view.init(target);
 		this._offData = this.matchData.init();
 		this._offCollected = this.checks.init();
-		this._offComments = this.comments.init();
 
+		// for some reason, this code will never run. I have no idea why. not totally sure what it does either.
 		this._deinit = () => {
+			console.log('Deinitializing app');
 			this._offState();
+			this._offComments();
 			this._offView();
 			this._offData();
 			this._offCollected();
-			this._offComments();
 		};
 
 		return this._deinit;
@@ -255,7 +257,14 @@ export class App {
 	reset() {
 		this._offState();
 		this._offCollected();
-		if (this._target) this.init(this._target);
+		this._offComments();
+
+		// wtf is this._deinit for?
+		// i do not understand
+		console.log('App reset.');
+		if (this._target) {
+			this.init(this._target);
+		}
 	}
 
 	goto(section: Section) {
@@ -458,7 +467,8 @@ To disable: ctrl + d`);
 		return attemptAsync(async () => {
 			const serialized = (await this.serialize()).unwrap();
 			(await AppData.submitMatch(serialized, true)).unwrap();
-			this.reset();
+			// I have a feeling this is not needed. the reset function is called from the svelte file, this just makes it get called twice.
+			// this.reset();
 		});
 	}
 }

--- a/src/lib/model/app/comments.ts
+++ b/src/lib/model/app/comments.ts
@@ -79,7 +79,11 @@ export class Comments implements Writable<C> {
 		this.addComment('Teleop', 'primary');
 		this.addComment('Overall', 'info');
 		return () => {
-			this.comments = [];
+
+			// the thermonuclear approach. this just doesn't want to work correctly.
+			this.comments.forEach(comment => comment.subscribers.clear());
+			this.set([]);
+			this.subscribers.clear();
 		};
 	}
 


### PR DESCRIPTION
The deinit function for comments was never actually being ran. As a side effect, the app is no longer reset twice and it feels snappier to submit/delete a match.